### PR TITLE
feature: adds support for arm64 images

### DIFF
--- a/.github/workflows/docker-hub-image-main.yml
+++ b/.github/workflows/docker-hub-image-main.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This quick fix enables `arm64` images to be built and published to Docker Hub. This platform is required to run the image on Mac M1, M2, Raspberry Pi, and other arm64-based machines.