### PR TITLE
Fix upload artifact version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,6 +70,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -59,14 +59,13 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
-          path: results.sarif
+          path: results-${{ strategy.job-index }}.sarif
           retention-days: 5
 
-      # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
+        uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: results.sarif
+          sarif_file: results-${{ strategy.job-index }}.sarif

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -33,7 +33,7 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
       - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         continue-on-error: true
         with:
           sarif_file: snyk-code.sarif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,13 +29,13 @@ jobs:
         include:
           - dockerfile: ./Dockerfile
             image: wazuh-agent-minideb
-            wazuh_cluster_version: '4.7.0'
+            wazuh_cluster_version: '4.11.2'
           - dockerfile: ./images/Dockerfile.amazonlinux
             image: wazuh-agent-amazonlinux
-            wazuh_cluster_version: '4.7.0'
+            wazuh_cluster_version: '4.11.2'
           - dockerfile: ./images/Dockerfile.ubuntu
             image: wazuh-agent-ubuntu
-            wazuh_cluster_version: '4.7.0'
+            wazuh_cluster_version: '4.11.2'
 
    steps:
    - uses: actions/checkout@v3
@@ -78,10 +78,10 @@ jobs:
         fetch-depth: 0
     - name: Expose GitHub Runtime
       uses: crazy-max/ghaction-github-runtime@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
       with:
-        python-version: "3.9"
+        python-version: "3.12"
         cache: 'pip'
     - name: Install dependencies
       run: |
@@ -105,9 +105,9 @@ jobs:
         AGENT_VERSION: "${{ matrix.wazuh_agent_version }}"
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: wazuh-unittests
+        name: wazuh-unittests-${{ strategy.job-index }}
         path: /tmp/test-results/wazuh-unittests-${{ matrix.wazuh_agent_version }}.xml
 
   integrations-tests:
@@ -116,7 +116,7 @@ jobs:
     strategy:
       matrix:
         wazuh_agent_version: ['4.3.10-1','4.4.5-1', '4.5.4-1','4.6.0-1','4.7.1-1','4.7.2-1']
-        wazuh_cluster_version: ['4.7.0']
+        wazuh_cluster_version: ['4.11.2']
         include:
           - image: wazuh-agent-minideb
           - image: wazuh-agent-amazonlinux
@@ -124,10 +124,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
       with:
-        python-version: "3.9"
+        python-version: "3.12"
         cache: 'pip'
 
     - name: Set up QEMU
@@ -148,16 +148,16 @@ jobs:
         key: docker-${{ matrix.wazuh_agent_version }}
 
     - name: Download artifact from build job
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: wazuh-unittests
+        name: wazuh-unittests-${{ strategy.job-index }}
         path: ${{ github.workspace }}/test-results/
 
     - name: Create single node certificates
-      run: docker-compose -f tests/single-node/generate-indexer-certs.yml run --rm generator
+      run: docker compose -f tests/single-node/generate-indexer-certs.yml run --rm generator
 
     - name: Start single node stack
-      run: docker-compose -f docker-compose.yml up -d --build
+      run: docker compose -f docker-compose.yml up -d --build
       env:
         AGENT_VERSION: "${{ matrix.wazuh_agent_version }}"
         WAZUH_CLUSTER_VERSION: "${{ matrix.wazuh_cluster_version }}"
@@ -203,4 +203,4 @@ jobs:
 
     - name: Stop containers and destroy
       if: always()
-      run: docker-compose -f docker-compose.yml down
+      run: docker compose -f docker-compose.yml down

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN install_packages python3-pip python3-setuptools python3-dev gcc && \
 FROM bitnami/minideb@sha256:bce8004f7da6547bc568e92895e1b3a3835e6dba48283fbbf9b3f66c1d166c6d
 LABEL maintainer="support@opennix.ru"
 LABEL description="Wazuh Docker Agent"
-ARG AGENT_VERSION="4.3.10-1"
+ARG AGENT_VERSION="4.7.2-1"
 ENV JOIN_MANAGER_MASTER_HOST=""
 ENV JOIN_MANAGER_WORKER_HOST=""
 ENV VIRUS_TOTAL_KEY=""

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ This implementation offers a seamless and adaptable solution for incorporating W
 >> Exercise caution, as potential bugs may exist in this branch. It is crucial to migrate all your deployments to Docker image tags listed below for reference.
 
 
-| GitHub branch/tag | Wazuh Agent version | EOL                | Docker image tag |
-|-------------------|---------------------|--------------------|------------------|
-| main              | v4.3.10             | v4.3.10 01.02.2024 | latest           |
-| v4.7.2-1          | v4.7.2-1            | LTS                | 4.7.1            |
-| v4.7.1-1          | v4.7.1-1            | LTS                | 4.7.1            |
-| v4.6.0-1          | v4.6.0-1            | LTS                | 4.6.0            |
-| v4.5.4-1          | v4.5.4-1            | LTS                | 4.5.4            |
-| v4.4.5-1          | v4.4.5-1            | LTS                | 4.4.5            |
+| GitHub branch/tag | Wazuh Agent version | EOL | Docker image tag |
+|-------------------|---------------------|-----|------------------|
+| main              | v4.7.2-1            | LTS | latest           |
+| v4.7.2-1          | v4.7.2-1            | LTS | 4.7.1            |
+| v4.7.1-1          | v4.7.1-1            | LTS | 4.7.1            |
+| v4.6.0-1          | v4.6.0-1            | LTS | 4.6.0            |
+| v4.5.4-1          | v4.5.4-1            | LTS | 4.5.4            |
+| v4.4.5-1          | v4.4.5-1            | LTS | 4.4.5            |
 
 ## DockerHub images
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-version: '3.9'  # optional since Compose v1.27.0
 services:
   wazuh-minideb-agent:
     build:

--- a/images/Dockerfile.ubuntu
+++ b/images/Dockerfile.ubuntu
@@ -1,10 +1,103 @@
 ARG TAG=@sha256:145bacc9db29ff9c9c021284e5b7b22f1193fc38556c578250c926cf3c883a13
-FROM ubuntu${TAG} as builder
-COPY requirements.txt /tmp
-RUN apt update && apt install python3-pip python3-setuptools python3-dev gcc -y && \
-     python3 -m pip wheel -w /tmp/wheel -r /tmp/requirements.txt
+FROM ubuntu${TAG}  AS base
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:$PATH"
+ENV LANG C.UTF-8
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update --quiet; \
+    apt-get install --yes --no-install-recommends \
+        bzip2 \
+        ca-certificates \
+        curl \
+        git \
+        libexpat1 \
+        make build-essential libssl-dev zlib1g-dev \
+        libbz2-dev libreadline-dev libsqlite3-dev curl git \
+        libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+    ; \
+    rm -rf /var/lib/apt/lists/*_dists_*
 
-FROM ubuntu${TAG}
+RUN set -eux; \
+    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash; \
+    git clone https://github.com/momo-lab/xxenv-latest \
+        ${PYENV_ROOT}/plugins/xxenv-latest \
+    ; \
+    pyenv update
+
+
+FROM base AS builder
+RUN set -eux; \
+    export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update --quiet; \
+    apt-get install --yes --no-install-recommends \
+        build-essential \
+        gdb \
+        lcov \
+        libbz2-dev \
+        libffi-dev \
+        libgdbm-compat-dev \
+        libgdbm-dev \
+        libncursesw5-dev \
+        $(apt-cache show libncurses-dev >/dev/null 2>&1 && echo libncurses-dev || true) \
+        libreadline6-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        lzma-dev \
+        pkg-config \
+        xz-utils \
+        tk-dev \
+        uuid-dev \
+        libxml2-dev \
+        libxmlsec1-dev \
+        libffi-dev \
+        liblzma-dev \
+        zlib1g-dev \
+    ; \
+    rm -rf /var/lib/apt/lists/*_dists_*
+
+
+FROM builder AS build-all
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:$PATH"
+ENV LANG C.UTF-8
+ENV PYTHON_CFLAG="-march=native -mtune=native"
+ARG PYENV_VERSIONS="3.12"
+ARG ALLOW_FAILURES=
+
+RUN set -eux; \
+    for version in ${PYENV_VERSIONS}; do \
+        env PYTHON_CONFIGURE_OPTS=" \
+            --enable-shared \
+            --enable-loadable-sqlite-extensions \
+            --with-lto \
+            --with-system-expat \
+            --with-system-ffi \
+            --with-system-mpdec \
+            --enable-optimizations \
+            " \
+            pyenv install ${version} || test -n "${ALLOW_FAILURES}"; \
+    done; \
+    pyenv global $(pyenv versions --bare | tac); \
+    pyenv versions; \
+    \
+    find ${PYENV_ROOT}/versions -depth \
+        \( \
+            \( -type d -a \( -name test -o -name tests -o -name idle_test \) \) \
+            -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' -o -name '*.a' \) \) \
+            -o \( -type f -a -name 'wininst-*.exe' \) \
+        \) -exec rm -rf '{}' +
+
+
+FROM build-all AS agent
+ENV LANG C.UTF-8
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:$PATH"
+COPY requirements.txt /tmp
+RUN pyenv global 3.12 && apt update && apt install python3-pip python3-setuptools python3-dev gcc -y && \
+     python -m pip wheel -w /tmp/wheel -r /tmp/requirements.txt
+
+FROM base
 LABEL maintainer="support@opennix.ru"
 LABEL description="Ubuntu 24.04 Wazuh Docker Agent"
 ARG AGENT_VERSION="4.3.10-1"
@@ -19,11 +112,19 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
+ENV PYENV_ROOT="/opt/pyenv"
+ENV PATH="${PYENV_ROOT}/shims:${PYENV_ROOT}/bin:$PATH"
+ENV LANG C.UTF-8
 ENV TZ=Etc/UTC
 COPY *.py *.jinja2  /var/ossec/
 WORKDIR /var/ossec/
-COPY --from=builder /tmp/wheel /tmp/wheel
-RUN apt update && apt install -y procps curl apt-transport-https gnupg2 inotify-tools python3-docker python3-setuptools python3-pip && \
+COPY --from=agent /tmp/wheel /tmp/wheel
+COPY --from=build-all ${PYENV_ROOT}/versions/ ${PYENV_ROOT}/versions/
+
+RUN pyenv rehash; \
+    pyenv global 3.12; \
+    pyenv versions && \
+    apt update && apt install -y procps curl apt-transport-https gnupg2 inotify-tools python3-docker python3-setuptools python3-pip && \
   curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | apt-key add - && \
   echo "deb https://packages.wazuh.com/4.x/apt/ stable main" | tee /etc/apt/sources.list.d/wazuh.list && \
   apt update && apt install -y wazuh-agent=${AGENT_VERSION}  && \
@@ -31,8 +132,8 @@ RUN apt update && apt install -y procps curl apt-transport-https gnupg2 inotify-
   apt install -y openjdk-11-jdk
 COPY *.py *.jinja2  /var/ossec/
 WORKDIR /var/ossec/
-COPY --from=builder /tmp/wheel /tmp/wheel
-RUN pip3 install --break-system-packages --no-index /tmp/wheel/*.whl && \
+COPY --from=agent /tmp/wheel /tmp/wheel
+RUN pyenv global 3.12 && pip3 install --no-index /tmp/wheel/*.whl && \
   chmod +x /var/ossec/deregister_agent.py && \
   chmod +x /var/ossec/register_agent.py && \
   apt-get clean autoclean && \

--- a/tests/ubuntu/test_wazuh_ubuntu.py
+++ b/tests/ubuntu/test_wazuh_ubuntu.py
@@ -15,7 +15,7 @@ def test_folders(host, srv_folders):
 def test_python_version(host):
     python = host.package("python3")
     assert python.is_installed
-    assert python.version.startswith("3.11")
+    assert python.version.startswith("3.12")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI actions upgraded to newer major versions (CodeQL v3, SARIF upload v3, setup-python v6, upload/download-artifact v4); artifact uploads now use job-indexed filenames. Replaced docker-compose calls with docker compose in workflows.
* **Refactor**
  * Docker image rebuilt as a multi-stage flow, standardized on Python 3.12, improved wheel build/consumption, runtime setup, permissions, and cleanup.
* **Tests**
  * Tests updated to expect Python 3.12.
* **Documentation**
  * README updated to reflect new agent version mappings and tags.
* **Chores**
  * Default agent version bumped in Dockerfile; top-level Compose version declaration removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->